### PR TITLE
Implement dynamic supply and demand for trading

### DIFF
--- a/Content.Server/_NF/Cargo/Systems/NFCargoSystem.Pallet.cs
+++ b/Content.Server/_NF/Cargo/Systems/NFCargoSystem.Pallet.cs
@@ -188,6 +188,10 @@ public sealed partial class NFCargoSystem
                 var price = _pricing.GetPrice(ent);
                 if (price == 0)
                     continue;
+
+                // Apply dynamic demand-based price adjustment
+                price = _dynamicPricing.AdjustPriceForGrid(gridUid, ent, price);
+
                 toSell.Add(ent);
 
                 // Check for items that are immune to market modifiers

--- a/Content.Server/_NF/Cargo/Systems/NFCargoSystem.cs
+++ b/Content.Server/_NF/Cargo/Systems/NFCargoSystem.cs
@@ -49,6 +49,7 @@ public sealed partial class NFCargoSystem : SharedNFCargoSystem
     [Dependency] private readonly SectorServiceSystem _sectorService = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
+    [Dependency] private readonly DynamicPricingSystem _dynamicPricing = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
     private EntityQuery<CargoSellBlacklistComponent> _blacklistQuery;

--- a/Content.Server/_NF/Market/Systems/DynamicPricingSystem.cs
+++ b/Content.Server/_NF/Market/Systems/DynamicPricingSystem.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Content.Server._NF.Market.Systems;
+using Content.Server._NF.Cargo.Systems;
+using Content.Server.Stack;
+using Content.Server.Station.Systems;
+using Content.Shared.Stacks;
+using Robust.Shared.Timing;
+using Robust.Shared.Prototypes;
+using Robust.Server.GameObjects;
+using Robust.Shared.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Random;
+using Robust.Shared.Log;
+using Content.Server._NF.Market.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
+using Content.Server.Cargo.Systems;
+using Content.Server.Cargo.Components;
+using Robust.Shared.Map;
+using Content.Server._NF.Atmos.Components;
+using Robust.Shared.Network;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+using Robust.Server.Player;
+
+namespace Content.Server._NF.Market.Systems;
+
+/// <summary>
+/// Tracks recent cargo sales per station and provides demand-based price multipliers.
+/// </summary>
+public sealed class DynamicPricingSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly StationSystem _stations = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+
+    private readonly Dictionary<EntityUid, StationState> _stateByStation = new();
+
+    // Default tuning (can be later moved to cvars or prototypes)
+    private const double OnlineMin = 12.0;
+    private const double OnlineMax = 120.0;
+
+    private const double AlphaLowDefault = 0.18;   // stronger damping at low online
+    private const double AlphaHighDefault = 0.06;  // weaker damping at high online
+    private static readonly TimeSpan TauDefault = TimeSpan.FromMinutes(60); // recovery half-life-ish scale
+
+    private const double FloorDefault = 0.15;      // min price fraction of base
+    private const double CapDefault = 1.20;        // max price fraction of base
+
+    // Optional step effect (disabled by default)
+    private const int StepAmountDefault = 15;   // quantity per step; 0 disables
+    private const double StepDropDefault = 0.05; // 5% drop per step
+
+    private sealed class PriceState
+    {
+        public double Supply; // accumulated, decayed quantity sold
+        public TimeSpan LastUpdate;
+    }
+
+    private sealed class StationState
+    {
+        public readonly Dictionary<string, PriceState> ByPrototype = new();
+        public TimeSpan LastCleanup;
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NFEntitySoldEvent>(OnEntitySold);
+    }
+
+    private StationState GetStationState(EntityUid station)
+    {
+        if (!_stateByStation.TryGetValue(station, out var st))
+        {
+            st = new StationState { LastCleanup = _timing.CurTime }; 
+            _stateByStation[station] = st;
+        }
+        return st;
+    }
+
+    private static double Clamp(double value, double min, double max) => Math.Min(max, Math.Max(min, value));
+
+    private static double Lerp(double a, double b, double t) => a + (b - a) * t;
+
+    private double GetOnlineNormalized()
+    {
+        var n = (double) _players.PlayerCount;
+        var x = (n - OnlineMin) / (OnlineMax - OnlineMin);
+        return Clamp(x, 0.0, 1.0);
+    }
+
+    private void Decay(ref PriceState ps, TimeSpan now, TimeSpan tau)
+    {
+        if (ps.LastUpdate == default)
+        {
+            ps.LastUpdate = now;
+            return;
+        }
+        var dt = (now - ps.LastUpdate).TotalSeconds;
+        if (dt <= 0)
+            return;
+        var factor = Math.Exp(-dt / tau.TotalSeconds);
+        ps.Supply *= factor;
+        ps.LastUpdate = now;
+    }
+
+    private PriceState GetProtoState(StationState stationState, string protoId)
+    {
+        if (!stationState.ByPrototype.TryGetValue(protoId, out var ps))
+        {
+            ps = new PriceState { Supply = 0, LastUpdate = _timing.CurTime };
+            stationState.ByPrototype[protoId] = ps;
+        }
+        return ps;
+    }
+
+    private void OnEntitySold(ref NFEntitySoldEvent ev)
+    {
+        // Find station by grid
+        var station = _stations.GetOwningStation(ev.Grid);
+        if (station is not { } stationUid)
+            return;
+
+        var stationState = GetStationState(stationUid);
+        var now = _timing.CurTime;
+
+        foreach (var sold in ev.Sold)
+        {
+            if (!TryComp<MetaDataComponent>(sold, out var meta) || meta.EntityPrototype is null)
+                continue;
+
+            // Determine sold quantity (1 or stack count)
+            var qty = 1;
+            if (TryComp<StackComponent>(sold, out var stack))
+            {
+                qty = stack.Count;
+            }
+
+            var protoId = meta.EntityPrototype.ID;
+            var ps = GetProtoState(stationState, protoId);
+            Decay(ref ps, now, TauDefault);
+            ps.Supply += qty;
+        }
+    }
+
+    /// <summary>
+    /// Compute demand-based multiplier for a given prototype on a station.
+    /// </summary>
+    private double ComputeMultiplier(EntityUid station, string protoId)
+    {
+        if (!_stateByStation.TryGetValue(station, out var stationState))
+            return 1.0; // no data yet
+
+        var ps = GetProtoState(stationState, protoId);
+        // Decay to now before computing
+        var now = _timing.CurTime;
+        Decay(ref ps, now, TauDefault);
+
+        // Online scaling: at low online use AlphaLow, at high online AlphaHigh
+        var x = GetOnlineNormalized();
+        var k = Lerp(AlphaHighDefault, AlphaLowDefault, 1.0 - x);
+
+        var supplyEffect = Math.Exp(-k * ps.Supply);
+
+        // Optional step effect
+        var stepEffect = 1.0;
+        if (StepAmountDefault > 0)
+        {
+            var steps = Math.Floor(ps.Supply / StepAmountDefault);
+            stepEffect = Math.Pow(1.0 - StepDropDefault, steps);
+        }
+
+        var baseEffect = Math.Max(supplyEffect, stepEffect);
+        var clamped = Clamp(baseEffect, FloorDefault, CapDefault);
+        return clamped;
+    }
+
+    /// <summary>
+    /// Adjust an entity's base price by demand factor for the station that owns the grid.
+    /// </summary>
+    public double AdjustPriceForGrid(EntityUid grid, EntityUid entity, double basePrice)
+    {
+        var station = _stations.GetOwningStation(grid);
+        if (station is not { } stationUid)
+            return basePrice;
+
+        if (!TryComp<MetaDataComponent>(entity, out var meta) || meta.EntityPrototype is null)
+            return basePrice;
+
+        var protoId = meta.EntityPrototype.ID;
+        var mult = ComputeMultiplier(stationUid, protoId);
+        return basePrice * mult;
+    }
+}


### PR DESCRIPTION
## О пулл-реквесте
Добавлена система динамического ценообразования для продажи предметов через торговые паллеты. Цена теперь зависит от объема недавних продаж и онлайна, постепенно восстанавливаясь со временем.

## Обоснование / Баланс
Изменение направлено на балансировку экономики, в частности, на снижение эффективности "денежного принтера" через ботанику и химию, а также на создание предпосылок для баффа других источников дохода (экспедиции, артефакты, газы, шахтерка). Чем больше единиц товара продано, тем ниже его цена. При низком онлайне цена падает сильнее, при высоком — мягче. Это должно стимулировать разнообразие способов заработка и предотвратить монополию одного вида фарма.

## Технические детали
- Добавлена новая серверная система `DynamicPricingSystem`, которая отслеживает объемы продаж каждого прототипа предмета для каждой станции.
- Продажи со временем "забываются" (экспоненциальный распад), что позволяет цене восстанавливаться.
- Множитель цены рассчитывается на основе накопленных продаж и текущего количества игроков на сервере (онлайна).
- Введена опциональная "ступенчатая" просадка цены (каждые N проданных единиц снижают цену на X%).
- Итоговая цена предмета ограничивается минимальным (15%) и максимальным (120%) значением от базовой цены.
- Логика интегрирована в `NFCargoSystem.Pallet.cs` для корректировки цены предметов при их оценке и продаже.
- Параметры системы (сила демпфера, время восстановления, пороги) заданы константами, но могут быть вынесены в конфиги/прототипы для тонкой настройки.

## Как протестировать
1. Разместите на торговой паллете большое количество одного и того же предмета (например, грибов или химикатов).
2. Продайте часть предметов и обратите внимание на снижение цены за единицу.
3. Продайте еще одну партию того же предмета и убедитесь, что цена упала еще сильнее.
4. Подождите некоторое время, не продавая этот предмет, и проверьте, как цена постепенно восстанавливается.
5. (Опционально) Протестируйте поведение системы при разном онлайне (например, с 12 игроками и с 50+), чтобы увидеть разницу в скорости падения/восстановления цены.

## Медиа
<!-- Приложите скриншоты/видео, если PR вносит изменения в игру (одежда, предметы, фичи и т.д.). 
Мелкие правки/рефакторинг не требуют. Медиа могут быть использованы в отчетах о разработке SS14 с указанием авторства. -->
Не требуются.

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [ ] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Я приложил медиа-материалы к этому PR или они не требуются.
- [ ] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [ ] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->

## Критические изменения
Нет.

**Журнал изменений**
<!-- Добавьте запись в журнал изменений, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на геймплей.
Убедитесь, что прочитали руководство и удалите этот шаблон из комментария, чтобы он отобразился.
Запись должна содержать символ :cl:, чтобы бот распознал изменения и добавил их в игровой журнал изменений. -->

<!--
:cl:
- tweak: Изменена экономика: введена динамическая система ценообразования на продажу предметов через паллеты. Цена теперь зависит от объема недавних продаж и онлайна, восстанавливаясь со временем.
-->

---
<a href="https://cursor.com/background-agent?bcId=bc-d8711199-afa9-4f85-81ed-69e7cb3856a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8711199-afa9-4f85-81ed-69e7cb3856a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

